### PR TITLE
aws sdk upgrade to current (resolves #46)

### DIFF
--- a/modules/providers/aws.js
+++ b/modules/providers/aws.js
@@ -233,7 +233,7 @@ exports.createKey = function (args) {
 
     var params = {
       KeyName: keyName,
-      PublicKeyMaterial: new Buffer(keyData).toString('base64')
+      PublicKeyMaterial: new Buffer(keyData)
     };
 
     ec2(args).importKeyPair(params, function (err, data) {
@@ -302,10 +302,9 @@ exports.getImages = function (args) {
 
 exports.getFilteredInstances = function (args) {
   args = args || {};
-
   return new Promise(function (resolve, reject) {
     ec2(args).describeInstances({
-      Filters: args.Filters || [],
+      Filters: args.Filters,
       InstanceIds: args.InstanceIds || args.InstanceId ? [args.InstanceId] : []
     }, function (err, data) {
       if (err) {

--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
     "overcast": "bin/overcast"
   },
   "dependencies": {
-    "aws-sdk": "2.0.0-rc.14",
+    "aws-sdk": "2.80.0",
     "bluebird": "1.2.1",
     "colors": "1.1.2",
     "overcast-do-wrapper": "3.11.2",


### PR DESCRIPTION
This PR upgrades aws SDK to current version. It is was needed to fix `aws create` to work with `eu-central-1` region. 

Automatic tests are passing. Tested manually on OSX with `us-east-1` and `eu-central-1` regions.