### PR TITLE
Add Vultr support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,4 @@ npm-debug.log
 libpeerconnection.log
 temp.md
 .overcast
+README_temp.md

--- a/README.md
+++ b/README.md
@@ -1051,6 +1051,192 @@ Description:
   Shut down a Virtualbox instance.
 ```
 
+### overcast vultr boot
+
+```
+Usage:
+  overcast vultr boot [name]
+
+Description:
+  Boot up an instance if powered off, otherwise do nothing.
+```
+
+### overcast vultr create
+
+```
+Usage:
+  overcast vultr create [name] [options...]
+
+Description:
+  Creates a new instance on Vultr.
+
+Options:                      Defaults:
+  --cluster CLUSTER           default
+  --ssh-port PORT             22
+  --ssh-key PATH              overcast.key
+  --ssh-pub-key PATH          overcast.key.pub
+  --region REGION/ID
+  --image OS/IMAGE
+  --plan SIZE
+  --enable-ipv6               false
+  --enable-private-network    false
+  --activation-email          false
+
+Examples:
+  # Create with defaults (Ubuntu 20.04, 1GB RAM, New Jersey region):
+  $ overcast vultr create vm-01
+
+  # Create with specific OS, plan and region:
+  $ overcast vultr create vm-02 --image "ubuntu_22_04_x64" --plan "vc2-2c-4gb" --region "lax"
+
+  # Create with additional options:
+  $ overcast vultr create vm-03 --enable-ipv6 --enable-private-network
+```
+
+### overcast vultr destroy
+
+```
+Usage:
+  overcast vultr destroy [name] [options...]
+
+Description:
+  Destroys a Vultr instance and removes it from your account.
+  Using --force overrides the confirm dialog.
+
+Options:     Defaults:
+  --force    false
+
+Examples:
+  $ overcast vultr destroy vm-01
+  $ overcast vultr destroy vm-01 --force
+```
+
+### overcast vultr images
+
+```
+Usage:
+  overcast vultr images
+
+Description:
+  List all available OS images, applications, and snapshots.
+```
+
+### overcast vultr instances
+
+```
+Usage:
+  overcast vultr instances
+
+Description:
+  List all instances in your account.
+```
+
+### overcast vultr reboot
+
+```
+Usage:
+  overcast vultr reboot [name]
+
+Description:
+  Reboot an instance using the provider API.
+```
+
+### overcast vultr regions
+
+```
+Usage:
+  overcast vultr regions
+
+Description:
+  List all available regions.
+```
+
+### overcast vultr rebuild
+
+```
+Usage:
+  overcast vultr rebuild [name] [image]
+
+Description:
+  Rebuilds an existing instance on Vultr, preserving the IP address.
+  [image] can be OS ID, OS name, image ID, or image name.
+
+Examples:
+  # Rebuild an instance using Ubuntu 22.04:
+  $ overcast vultr rebuild vm-01 ubuntu_22_04_x64
+
+  # Rebuild an instance using a snapshot:
+  $ overcast vultr rebuild vm-01 "My Custom Image"
+```
+
+### overcast vultr resize
+
+```
+Usage:
+  overcast vultr resize [name] [plan]
+
+Description:
+  Shut down, resize, and boot a Vultr instance.
+  [plan] can be plan ID or name.
+
+Examples:
+  # Resize an instance to a 4GB plan:
+  $ overcast vultr resize vm-01 vc2-2c-4gb
+```
+
+### overcast vultr snapshot
+
+```
+Usage:
+  overcast vultr snapshot [name] [snapshot-name]
+
+Description:
+  Creates a named snapshot of an instance.
+
+Examples:
+  $ overcast vultr snapshot vm-01 vm-01-backup
+```
+
+### overcast vultr snapshots
+
+```
+Usage:
+  overcast vultr snapshots
+
+Description:
+  List all snapshots in your account.
+```
+
+### overcast vultr shutdown
+
+```
+Usage:
+  overcast vultr shutdown [name]
+
+Description:
+  Shut down an instance using the provider API.
+```
+
+### overcast vultr plans
+
+```
+Usage:
+  overcast vultr plans
+
+Description:
+  List all available instance plans.
+```
+
+### overcast vultr sync
+
+```
+Usage:
+  overcast vultr sync [name]
+
+Description:
+  Fetch and update instance metadata.
+```
+
 ### overcast wait
 
 ```

--- a/README.md
+++ b/README.md
@@ -57,7 +57,7 @@ A library of [scripts](https://github.com/andrewchilds/overcast/tree/master/scri
 3. You can now use Overcast from any directory. Running any overcast command from anywhere will create the `~/.overcast` config directory if it doesn't already exist. Add your API keys to `~/.overcast/variables.json` to use their respective commands, either manually or using the `var` command:
 
     ```sh
-    $ overcast var set DIGITALOCEAN_API_TOKEN abc123
+    $ overcast vars set DIGITALOCEAN_API_TOKEN abc123
     ```
 
 4. To make working with Overcast easier, you can add bash tab completion by adding the following to your `.bash_profile`:
@@ -761,7 +761,7 @@ Description:
   Sends a message to a Slack channel.
   Requires a SLACK_WEBHOOK_URL property to be set in variables.json.
   You can set that with the following command:
-  overcast var set SLACK_WEBHOOK_URL https://foo.slack.com/blah
+  overcast vars set SLACK_WEBHOOK_URL https://foo.slack.com/blah
 
 Options:                Defaults:
   --channel NAME        #alerts

--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
   "main": "overcast.js",
   "scripts": {
     "test": "cd test && npx jasmine --random=false integration/*.spec.js",
-    "docs": "node bin/overcast-docs.js > temp.md"
+    "docs": "node bin/overcast-docs.js > README_temp.md && echo 'Add README_temp.md to the Command Reference section of the README.md and then commit the changes.'"
   },
   "bin": {
     "overcast": "./overcast.js"

--- a/src/commands/index.js
+++ b/src/commands/index.js
@@ -21,6 +21,7 @@ import * as sshkey from './sshkey.js';
 import * as tunnel from './tunnel.js';
 import * as vars from './vars.js';
 import * as virtualbox from './virtualbox.js';
+import * as vultr from './vultr.js';
 import * as wait from './wait.js';
 
 export default {
@@ -47,5 +48,6 @@ export default {
   tunnel,
   vars,
   virtualbox,
+  vultr,
   wait
 };

--- a/src/commands/slack.js
+++ b/src/commands/slack.js
@@ -12,7 +12,7 @@ commands.slack = {
     'Sends a message to a Slack channel.',
     'Requires a SLACK_WEBHOOK_URL property to be set in variables.json.',
     'You can set that with the following command:',
-    'overcast var set SLACK_WEBHOOK_URL https://foo.slack.com/blah'
+    'overcast vars set SLACK_WEBHOOK_URL https://foo.slack.com/blah'
   ],
   examples: [
     '$ overcast slack "Deploy completed." --icon-emoji ":satelite:"',

--- a/src/commands/vultr.js
+++ b/src/commands/vultr.js
@@ -2,9 +2,10 @@ import * as filters from '../filters.js';
 import * as provider from '../provider.js';
 import { isTestRun } from '../utils.js';
 import { api } from '../providers/vultr.js';
+import { mockAPI } from '../providers/mock.js';
 
 function getAPI() {
-  return api;
+  return isTestRun() ? mockAPI : api;
 }
 
 export const commands = {};

--- a/src/commands/vultr.js
+++ b/src/commands/vultr.js
@@ -1,0 +1,220 @@
+import * as filters from '../filters.js';
+import * as provider from '../provider.js';
+import { isTestRun } from '../utils.js';
+import { api } from '../providers/vultr.js';
+
+function getAPI() {
+  return api;
+}
+
+export const commands = {};
+
+commands.boot = {
+  name: 'boot',
+  usage: ['overcast vultr boot [name]'],
+  description: 'Boot up an instance if powered off, otherwise do nothing.',
+  required: [
+    { name: 'name', filters: [filters.findFirstMatchingInstance, filters.shouldBeVultr] }
+  ],
+  run: (args, nextFn) => {
+    provider.boot(getAPI(), args, nextFn);
+  }
+};
+
+commands.poweron = Object.assign({ alias: true }, commands.boot);
+
+commands.create = {
+  name: 'create',
+  usage: ['overcast vultr create [name] [options...]'],
+  description: ['Creates a new instance on Vultr.'],
+  examples: [
+    '# Create with defaults (Ubuntu 20.04, 1GB RAM, New Jersey region):',
+    '$ overcast vultr create vm-01',
+    '',
+    '# Create with specific OS, plan and region:',
+    '$ overcast vultr create vm-02 --image "ubuntu_22_04_x64" --plan "vc2-2c-4gb" --region "lax"',
+    '',
+    '# Create with additional options:',
+    '$ overcast vultr create vm-03 --enable-ipv6 --enable-private-network'
+  ],
+  required: [
+    { name: 'name', filters: filters.shouldBeNewInstance }
+  ],
+  options: [
+    { usage: '--cluster CLUSTER', default: 'default' },
+    { usage: '--ssh-port PORT', default: '22' },
+    { usage: '--ssh-key PATH', default: 'overcast.key' },
+    { usage: '--ssh-pub-key PATH', default: 'overcast.key.pub' },
+    { usage: '--region REGION/ID', default: api.DEFAULT_REGION },
+    { usage: '--image OS/IMAGE', default: api.DEFAULT_IMAGE },
+    { usage: '--plan SIZE', default: api.DEFAULT_PLAN },
+    { usage: '--enable-ipv6', default: 'false' },
+    { usage: '--enable-private-network', default: 'false' },
+    { usage: '--activation-email', default: 'false' }
+  ],
+  run: (args, nextFn) => {
+    provider.create(getAPI(), args, nextFn);
+  }
+};
+
+commands.destroy = {
+  name: 'destroy',
+  usage: ['overcast vultr destroy [name] [options...]'],
+  description: [
+    'Destroys a Vultr instance and removes it from your account.',
+    'Using --force overrides the confirm dialog.'
+  ],
+  examples: [
+    '$ overcast vultr destroy vm-01',
+    '$ overcast vultr destroy vm-01 --force'
+  ],
+  required: [
+    { name: 'name', filters: [filters.findFirstMatchingInstance, filters.shouldBeVultr] }
+  ],
+  options: [
+    { usage: '--force', default: 'false' }
+  ],
+  run: (args, nextFn) => {
+    provider.destroy(getAPI(), args, nextFn);
+  }
+};
+
+commands.images = {
+  name: 'images',
+  usage: ['overcast vultr images'],
+  description: 'List all available OS images, applications, and snapshots.',
+  run: (args, nextFn) => {
+    provider.images(getAPI(), nextFn);
+  }
+};
+
+commands.instances = {
+  name: 'instances',
+  usage: ['overcast vultr instances'],
+  description: 'List all instances in your account.',
+  run: (args, nextFn) => {
+    provider.instances(getAPI(), args, nextFn);
+  }
+};
+
+commands.reboot = {
+  name: 'reboot',
+  usage: ['overcast vultr reboot [name]'],
+  description: 'Reboot an instance using the provider API.',
+  required: [
+    { name: 'name', filters: [filters.findFirstMatchingInstance, filters.shouldBeVultr] }
+  ],
+  run: (args, nextFn) => {
+    provider.reboot(getAPI(), args, nextFn);
+  }
+};
+
+commands.regions = {
+  name: 'regions',
+  usage: ['overcast vultr regions'],
+  description: 'List all available regions.',
+  run: (args, nextFn) => {
+    provider.regions(getAPI(), nextFn);
+  }
+};
+
+commands.rebuild = {
+  name: 'rebuild',
+  usage: ['overcast vultr rebuild [name] [image]'],
+  description: [
+    'Rebuilds an existing instance on Vultr, preserving the IP address.',
+    '[image] can be OS ID, OS name, image ID, or image name.'
+  ],
+  examples: [
+    '# Rebuild an instance using Ubuntu 22.04:',
+    '$ overcast vultr rebuild vm-01 ubuntu_22_04_x64',
+    '',
+    '# Rebuild an instance using a snapshot:',
+    '$ overcast vultr rebuild vm-01 "My Custom Image"'
+  ],
+  required: [
+    { name: 'name', filters: [filters.findFirstMatchingInstance, filters.shouldBeVultr] },
+    { name: 'image' }
+  ],
+  run: (args, nextFn) => {
+    provider.rebuild(getAPI(), args, nextFn);
+  }
+};
+
+commands.resize = {
+  name: 'resize',
+  usage: ['overcast vultr resize [name] [plan]'],
+  description: [
+    'Shut down, resize, and boot a Vultr instance.',
+    '[plan] can be plan ID or name.'
+  ],
+  examples: [
+    '# Resize an instance to a 4GB plan:',
+    '$ overcast vultr resize vm-01 vc2-2c-4gb'
+  ],
+  required: [
+    { name: 'name', filters: [filters.findFirstMatchingInstance, filters.shouldBeVultr] },
+    { name: 'size' }
+  ],
+  run: (args, nextFn) => {
+    provider.resize(getAPI(), args, nextFn);
+  }
+};
+
+commands.snapshot = {
+  name: 'snapshot',
+  usage: ['overcast vultr snapshot [name] [snapshot-name]'],
+  description: 'Creates a named snapshot of an instance.',
+  examples: '$ overcast vultr snapshot vm-01 vm-01-backup',
+  required: [
+    { name: 'name', filters: [filters.findFirstMatchingInstance, filters.shouldBeVultr] },
+    { name: 'snapshot-name', varName: 'snapshotName' }
+  ],
+  run: (args, nextFn) => {
+    provider.snapshot(getAPI(), args, nextFn);
+  }
+};
+
+commands.snapshots = {
+  name: 'snapshots',
+  usage: ['overcast vultr snapshots'],
+  description: 'List all snapshots in your account.',
+  run: (args, nextFn) => {
+    provider.snapshots(getAPI(), nextFn);
+  }
+};
+
+commands.shutdown = {
+  name: 'shutdown',
+  usage: ['overcast vultr shutdown [name]'],
+  description: 'Shut down an instance using the provider API.',
+  required: [
+    { name: 'name', filters: [filters.findFirstMatchingInstance, filters.shouldBeVultr] }
+  ],
+  run: (args, nextFn) => {
+    provider.shutdown(getAPI(), args, nextFn);
+  }
+};
+
+commands.plans = {
+  name: 'plans',
+  usage: ['overcast vultr plans'],
+  description: 'List all available instance plans.',
+  run: (args, nextFn) => {
+    provider.sizes(getAPI(), nextFn);
+  }
+};
+
+commands.sizes = Object.assign({ alias: true }, commands.plans);
+
+commands.sync = {
+  name: 'sync',
+  usage: ['overcast vultr sync [name]'],
+  description: 'Fetch and update instance metadata.',
+  required: [
+    { name: 'name', filters: [filters.findFirstMatchingInstance, filters.shouldBeVultr] }
+  ],
+  run: (args, nextFn) => {
+    provider.sync(getAPI(), args, nextFn);
+  }
+};

--- a/src/filters.js
+++ b/src/filters.js
@@ -71,7 +71,7 @@ export function shouldBeExistingKey(name, args) {
   }
 }
 
-export function shouldBeDigitalOcean(name, {instance}) {
+export function shouldBeDigitalOcean(name, { instance }) {
   if (!instance || !instance.digitalocean) {
     log.failure('This instance has no DigitalOcean metadata attached.');
     log.failure('Run this command and then try again:');
@@ -79,8 +79,14 @@ export function shouldBeDigitalOcean(name, {instance}) {
   }
 }
 
-export function shouldBeVirtualbox(name, {instance}) {
+export function shouldBeVirtualbox(name, { instance }) {
   if (!instance || !instance.virtualbox) {
     return utils.die('This instance has no Virtualbox metadata attached.');
+  }
+}
+
+export function shouldBeVultr(name, { instance }) {
+  if (!instance || !instance.vultr) {
+    return utils.die(`Instance "${instance.name}" is not a Vultr instance.`);
   }
 }

--- a/src/providers/ADDING_PROVIDERS.md
+++ b/src/providers/ADDING_PROVIDERS.md
@@ -182,7 +182,7 @@ function getAPI() {
     log.failure('The variable YOUR_PROVIDER_API_KEY is not set.');
     log.failure('Go to https://your-provider.com/settings/api');
     log.failure('to get your API key, then run the following command:');
-    return utils.die('overcast var set YOUR_PROVIDER_API_KEY [your_api_key]');
+    return utils.die('overcast vars set YOUR_PROVIDER_API_KEY [your_api_key]');
   }
 
   // Initialize your provider's API client with the credentials

--- a/src/providers/ADDING_PROVIDERS.md
+++ b/src/providers/ADDING_PROVIDERS.md
@@ -1,0 +1,251 @@
+# Implementing a New Provider for Overcast
+
+Overcast is designed with a modular provider system that allows you to add support for different cloud providers. This guide will walk you through implementing a new provider for Overcast.
+
+## Provider Interface Overview
+
+A provider in Overcast consists of two main components:
+
+1. **Provider API Module** - The implementation of cloud provider-specific API calls
+2. **Provider Command Module** - The CLI commands that expose provider functionality
+
+## Step 1: Create the Provider API Module
+
+Create a new file in `/src/providers/your-provider.js` that exports an API object.
+
+```javascript
+import * as utils from '../utils.js';
+import * as log from '../log.js';
+
+export const api = {
+  id: 'your-provider',
+  name: 'Your Provider Name'
+};
+
+// Optional default values for provider
+export const DEFAULT_IMAGE = 'ubuntu-20-04';
+export const DEFAULT_SIZE = 'medium';
+export const DEFAULT_REGION = 'us-east';
+
+// Required provider methods implementation
+```
+
+### Required Provider Methods
+
+The provider API must implement some or all of the following methods. At minimum, you should implement `create` and `destroy`:
+
+```javascript
+// Core instance management methods
+api.create = (args, nextFn = () => {}) => {
+  // Create a new instance and call nextFn with instance data
+  // The instance object should include name, ip, ssh_key, ssh_port, user, and provider-specific data
+};
+
+api.destroy = (instance, nextFn = () => {}) => {
+  // Destroy the instance and call nextFn when complete
+};
+
+// Instance power management methods
+api.boot = (instance, nextFn = () => {}) => {
+  // Power on the instance
+};
+
+api.shutdown = (instance, nextFn = () => {}) => {
+  // Gracefully shut down the instance
+};
+
+api.reboot = (instance, nextFn = () => {}) => {
+  // Reboot the instance
+};
+
+// Instance configuration methods
+api.rebuild = (instance, image, nextFn = () => {}) => {
+  // Rebuild an instance with a new image
+};
+
+api.resize = (instance, size, nextFn = () => {}) => {
+  // Change the instance size/resources
+};
+
+api.snapshot = (instance, snapshotName, nextFn = () => {}) => {
+  // Create a snapshot of the instance
+};
+
+// Information retrieval methods
+api.getImages = (nextFn = () => {}) => {
+  // Return available images
+};
+
+api.getInstances = (args, nextFn = () => {}) => {
+  // Return all instances from the provider
+};
+
+api.getInstance = (instance, nextFn = () => {}) => {
+  // Get detailed information about a specific instance
+};
+
+api.updateInstanceMetadata = (instance, nextFn = () => {}) => {
+  // Update the stored metadata for an instance
+};
+
+api.sync = (instance, nextFn = () => {}) => {
+  // Sync instance data with the provider
+};
+
+api.getRegions = (nextFn = () => {}) => {
+  // Return available regions
+};
+
+api.getSizes = (nextFn = () => {}) => {
+  // Return available instance sizes
+};
+
+api.getSnapshots = (nextFn = () => {}) => {
+  // Return available snapshots
+};
+```
+
+## Step 2: Create the Provider Command Module
+
+Create a new file in `/src/commands/your-provider.js` that defines the CLI commands for your provider:
+
+```javascript
+import * as filters from '../filters.js';
+import * as provider from '../provider.js';
+import { isTestRun } from '../utils.js';
+import { api } from '../providers/your-provider.js';
+import { mockAPI } from '../providers/mock.js';
+
+function getAPI() {
+  return isTestRun() ? mockAPI : api;
+}
+
+export const commands = {};
+
+// Optional banner message for this provider
+export const banner = [
+  'These commands require YourProvider credentials to be set.',
+  'Set YOUR_PROVIDER_API_KEY in variables.json to use these commands.'
+];
+
+// Define commands that map to provider API functionality
+```
+
+### Defining Provider Commands
+
+For each provider capability you want to expose as a CLI command:
+
+```javascript
+commands.create = {
+  name: 'create',
+  usage: ['overcast your-provider create [name] [options...]'],
+  description: ['Creates a new instance on Your Provider.'],
+  examples: [
+    '# Create a basic instance:',
+    '$ overcast your-provider create vm-01 --size medium --region us-east'
+  ],
+  required: [
+    { name: 'name', filters: filters.shouldBeNewInstance }
+  ],
+  options: [
+    { usage: '--cluster CLUSTER', default: 'default' },
+    { usage: '--ssh-port PORT', default: '22' },
+    { usage: '--ssh-key PATH', default: 'overcast.key' },
+    { usage: '--region REGION', default: api.DEFAULT_REGION },
+    { usage: '--image IMAGE', default: api.DEFAULT_IMAGE },
+    { usage: '--size SIZE', default: api.DEFAULT_SIZE }
+    // Add any provider-specific options here
+  ],
+  run: (args, nextFn) => {
+    provider.create(getAPI(), args, nextFn);
+  }
+};
+
+// Add other commands like destroy, boot, shutdown, etc.
+```
+
+## Step 3: Handle Provider-Specific Authentication
+
+In most cases, your provider will need authentication credentials. These should be stored in the Overcast variables.json file:
+
+1. Document the required credentials in your provider's banner
+2. Add code to check for these credentials in your provider API module:
+
+```javascript
+function getAPI() {
+  if (PRIVATE_CACHE.API) {
+    return PRIVATE_CACHE.API;
+  }
+
+  const vars = utils.getVariables();
+  if (!vars.YOUR_PROVIDER_API_KEY) {
+    log.failure('The variable YOUR_PROVIDER_API_KEY is not set.');
+    log.failure('Go to https://your-provider.com/settings/api');
+    log.failure('to get your API key, then run the following command:');
+    return utils.die('overcast var set YOUR_PROVIDER_API_KEY [your_api_key]');
+  }
+
+  // Initialize your provider's API client with the credentials
+  PRIVATE_CACHE.API = new YourProviderClient(vars.YOUR_PROVIDER_API_KEY);
+
+  return PRIVATE_CACHE.API;
+}
+```
+
+## Step 4: Implement Instance Metadata Structure
+
+When creating instances, your provider should return consistent instance metadata. Here's an example structure:
+
+```javascript
+const instanceMetadata = {
+  name: 'vm-name',          // Instance name in Overcast
+  ip: '123.456.789.0',      // Public IP address
+  ssh_key: 'overcast.key',  // SSH key path
+  ssh_port: '22',           // SSH port
+  user: 'root',             // Default SSH user
+  your_provider: {          // Provider-specific metadata
+    id: 'instance-id',
+    region: 'us-east',
+    size: 'medium',
+    image: 'ubuntu-20.04',
+    // Include any other provider-specific details
+  }
+};
+```
+
+## Step 5: Testing Your Provider
+
+1. Create a mock implementation for testing:
+   - Either extend the existing mock API in mock.js
+   - Or create test-specific mock responses
+
+2. Test key provider flows:
+   - Instance creation and destruction
+   - Power management operations
+   - Configuration changes (resize, rebuild)
+
+## Best Practices
+
+1. **Error Handling**: Use a consistent approach for error handling, similar to the `genericCatch` function in the DigitalOcean provider.
+
+2. **Async Operations**: Most cloud provider APIs are asynchronous. Use promises or callbacks consistently.
+
+3. **User Feedback**: Provide clear feedback about operations using `log.success`, `log.faded`, and `log.failure`.
+
+4. **Documentation**: Add examples to command descriptions showing how to use your provider's specific features.
+
+5. **Validation**: Validate inputs before making API calls to prevent errors.
+
+## Complete Example Structure
+
+Your final implementation should include:
+
+1. `/src/providers/your-provider.js` - Provider API implementation
+2. `/src/commands/your-provider.js` - CLI commands for your provider
+
+To make your provider available in Overcast, you'll also need to:
+
+1. Import your command module in the main `providers/index.js` and `commands/index.js` files
+2. Generate documentation for your provider in the README.md using `npm run docs`
+
+By following these guidelines, you can create a new provider that integrates seamlessly with the Overcast ecosystem.

--- a/src/providers/digitalocean.js
+++ b/src/providers/digitalocean.js
@@ -174,7 +174,7 @@ export function getAPI() {
     log.failure('The variable DIGITALOCEAN_API_TOKEN is not set.');
     log.failure('Go to https://cloud.digitalocean.com/settings/applications');
     log.failure('to get your API token, then run the following command:');
-    return utils.die('overcast var set DIGITALOCEAN_API_TOKEN [your_api_token]');
+    return utils.die('overcast vars set DIGITALOCEAN_API_TOKEN [your_api_token]');
   }
 
   PRIVATE_CACHE.API = new DigitalOcean.default(vars.DIGITALOCEAN_API_TOKEN);

--- a/src/providers/index.js
+++ b/src/providers/index.js
@@ -1,7 +1,9 @@
 import * as digitalocean from './digitalocean.v2.js';
 import * as virtualbox from './virtualbox.js';
+import * as vultr from './vultr.js';
 
 export default {
   digitalocean,
-  virtualbox
+  virtualbox,
+  vultr
 };

--- a/src/providers/mock.js
+++ b/src/providers/mock.js
@@ -12,7 +12,8 @@ mockAPI.create = (args, nextFn) => {
     ssh_port: args['ssh-port'],
     // Including these here to bypass filters
     virtualbox: {},
-    digitalocean: {}
+    digitalocean: {},
+    vultr: {},
   }));
 }
 
@@ -116,6 +117,12 @@ const MOCK_REGIONS = [
 ];
 
 const MOCK_KEYS = [];
+
+const MOCK_SIZES = [
+  { name: '512MB' },
+  { name: '1GB' },
+  { name: '2GB' }
+];
 
 const MOCK_INSTANCES = [
   mockInstance({ name: 'mock-01' })

--- a/src/providers/vultr.js
+++ b/src/providers/vultr.js
@@ -1,0 +1,609 @@
+import https from 'https';
+import fs from 'fs';
+import * as log from '../log.js';
+import * as utils from '../utils.js';
+
+export const api = {
+  id: 'vultr',
+  name: 'Vultr'
+};
+
+export const DEFAULT_IMAGE = 'ubuntu_20_04_x64'; // Ubuntu 20.04 x64
+export const DEFAULT_PLAN = 'vc2-1c-1gb'; // 1 CPU, 1GB RAM
+export const DEFAULT_REGION = 'ewr'; // New Jersey (NJ)
+
+// Provider interface
+api.create = (args, nextFn) => {
+  args['ssh-pub-key'] = utils.normalizeKeyPath(args['ssh-pub-key'], 'overcast.key.pub');
+
+  normalizeAndFindPropertiesForCreate(args, () => {
+    getOrCreateOvercastKeyID(args['ssh-pub-key'], keyID => {
+      const data = {
+        region: args['region-id'],
+        plan: args['plan-id'],
+        sshkey_id: [keyID],
+        label: args.name,
+        hostname: args.name,
+        enable_ipv6: utils.argIsTruthy(args['enable-ipv6']),
+        enable_private_network: utils.argIsTruthy(args['enable-private-network']),
+        activation_email: utils.argIsTruthy(args['activation-email']),
+      };
+
+      // Add OS or image ID (but not both)
+      if (args['os-id']) {
+        data.os_id = args['os-id'];
+      } else if (args['image-id']) {
+        data.image_id = args['image-id'];
+      }
+
+      // Remove any undefined values
+      Object.keys(data).forEach(key => {
+        if (data[key] === undefined) {
+          delete data[key];
+        }
+      });
+
+      _create(args, data, nextFn);
+    });
+  });
+};
+
+api.destroy = (instance, nextFn = () => {}) => {
+  apiRequest({
+    method: 'DELETE',
+    path: `/instances/${instance.vultr.id}`
+  }, () => {
+    nextFn();
+  });
+};
+
+api.boot = (instance, nextFn) => {
+  apiRequest({
+    method: 'POST',
+    path: `/instances/${instance.vultr.id}/start`
+  }, () => {
+    api.updateInstanceMetadata(instance, nextFn);
+  });
+};
+
+api.shutdown = (instance, nextFn) => {
+  apiRequest({
+    method: 'POST',
+    path: `/instances/${instance.vultr.id}/halt`
+  }, () => {
+    api.updateInstanceMetadata(instance, nextFn);
+  });
+};
+
+api.reboot = (instance, nextFn) => {
+  apiRequest({
+    method: 'POST',
+    path: `/instances/${instance.vultr.id}/reboot`
+  }, () => {
+    api.updateInstanceMetadata(instance, nextFn);
+  });
+};
+
+api.rebuild = (instance, imageIdOrOsId, nextFn) => {
+  // First check OS list
+  apiRequest({
+    method: 'GET',
+    path: '/os'
+  }, osData => {
+    const osList = osData.os || [];
+    const foundOS = osList.find(os =>
+      os.id.toString() === imageIdOrOsId.toString() ||
+      os.name.toLowerCase() === imageIdOrOsId.toLowerCase() ||
+      imageIdOrOsId.toLowerCase().includes(os.name.toLowerCase())
+    );
+
+    if (foundOS) {
+      // It's an OS
+      apiRequest({
+        method: 'POST',
+        path: `/instances/${instance.vultr.id}/reinstall`,
+        data: {
+          os_id: foundOS.id
+        }
+      }, () => {
+        waitForInstanceToBecomeActive(instance.vultr.id, () => {
+          api.updateInstanceMetadata(instance, nextFn);
+        });
+      });
+    } else {
+      // Check if it's an image
+      apiRequest({
+        method: 'GET',
+        path: '/images'
+      }, imagesData => {
+        const images = imagesData.images || [];
+        const foundImage = images.find(img =>
+          img.id.toString() === imageIdOrOsId.toString() ||
+          img.name.toLowerCase() === imageIdOrOsId.toLowerCase() ||
+          imageIdOrOsId.toLowerCase().includes(img.name.toLowerCase())
+        );
+
+        if (foundImage) {
+          apiRequest({
+            method: 'POST',
+            path: `/instances/${instance.vultr.id}/reinstall`,
+            data: {
+              image_id: foundImage.id
+            }
+          }, () => {
+            waitForInstanceToBecomeActive(instance.vultr.id, () => {
+              api.updateInstanceMetadata(instance, nextFn);
+            });
+          });
+        } else {
+          utils.die(`No OS or image found that matches "${imageIdOrOsId}".`);
+        }
+      });
+    }
+  });
+};
+
+api.resize = (instance, planId, nextFn) => {
+  apiRequest({
+    method: 'GET',
+    path: '/plans'
+  }, data => {
+    const plans = data.plans || [];
+    const foundPlan = plans.find(plan =>
+      plan.id.toString() === planId.toString() ||
+      plan.id.toLowerCase() === planId.toLowerCase() ||
+      planId.toLowerCase().includes(plan.id.toLowerCase())
+    );
+
+    if (!foundPlan) {
+      return utils.die(`No plan found that matches "${planId}".`);
+    }
+
+    // Check if instance is powered off
+    api.getInstance(instance, vultrInstance => {
+      if (vultrInstance.power_status === 'running') {
+        log.faded('Shutting down instance before resize...');
+        api.shutdown(instance, () => {
+          waitForInstanceToBePoweredOff(instance.vultr.id, () => {
+            performResize(instance, foundPlan.id, nextFn);
+          });
+        });
+      } else {
+        performResize(instance, foundPlan.id, nextFn);
+      }
+    });
+  });
+};
+
+function performResize(instance, planId, nextFn) {
+  apiRequest({
+    method: 'POST',
+    path: `/instances/${instance.vultr.id}/resize`,
+    data: {
+      plan: planId
+    }
+  }, () => {
+    log.faded('Plan upgraded. Starting instance...');
+    waitForInstanceToBecomeActive(instance.vultr.id, () => {
+      api.boot(instance, nextFn);
+    });
+  });
+}
+
+api.snapshot = (instance, snapshotName, nextFn) => {
+  // Check if instance is powered off
+  api.getInstance(instance, vultrInstance => {
+    if (vultrInstance.power_status === 'running') {
+      log.faded('Shutting down instance before taking snapshot...');
+      api.shutdown(instance, () => {
+        waitForInstanceToBePoweredOff(instance.vultr.id, () => {
+          createSnapshot(instance, snapshotName, nextFn);
+        });
+      });
+    } else {
+      createSnapshot(instance, snapshotName, nextFn);
+    }
+  });
+};
+
+function createSnapshot(instance, snapshotName, nextFn) {
+  apiRequest({
+    method: 'POST',
+    path: `/instances/${instance.vultr.id}/snapshots`,
+    data: {
+      description: snapshotName
+    }
+  }, data => {
+    log.faded('Snapshot creation started. This may take several minutes.');
+    log.faded('Starting instance...');
+    api.boot(instance, nextFn);
+  });
+}
+
+api.getImages = (nextFn) => {
+  // Combine OS list with snapshots and other images
+  apiRequest({
+    method: 'GET',
+    path: '/os'
+  }, osData => {
+    const osList = osData.os || [];
+
+    apiRequest({
+      method: 'GET',
+      path: '/images'
+    }, imagesData => {
+      const images = imagesData.images || [];
+
+      const result = {
+        os: osList.map(os => ({
+          id: os.id,
+          name: os.name,
+          family: 'os',
+          type: 'os'
+        })),
+        snapshots: images.filter(img => img.type === 'snapshot').map(img => ({
+          id: img.id,
+          name: img.name,
+          description: img.description,
+          size: img.size,
+          status: img.status,
+          type: 'snapshot'
+        })),
+        applications: images.filter(img => img.type === 'application').map(img => ({
+          id: img.id,
+          name: img.name,
+          description: img.description,
+          type: 'application'
+        }))
+      };
+
+      nextFn(result);
+    });
+  });
+};
+
+api.getInstances = (args, nextFn) => {
+  apiRequest({
+    method: 'GET',
+    path: '/instances'
+  }, data => {
+    nextFn(data.instances || []);
+  });
+};
+
+api.getInstance = (instance, nextFn) => {
+  const id = utils.isObject(instance) && instance.vultr ? instance.vultr.id : instance;
+
+  apiRequest({
+    method: 'GET',
+    path: `/instances/${id}`
+  }, data => {
+    nextFn(data.instance);
+  });
+};
+
+api.updateInstanceMetadata = (instance, nextFn = () => {}) => {
+  api.getInstance(instance, vultrInstance => {
+    utils.updateInstance(instance.name, {
+      ip: vultrInstance.main_ip,
+      vultr: vultrInstance
+    }, () => {
+      nextFn();
+    });
+  });
+};
+
+api.sync = api.updateInstanceMetadata;
+
+api.getRegions = (nextFn) => {
+  apiRequest({
+    method: 'GET',
+    path: '/regions'
+  }, data => {
+    nextFn(data.regions || []);
+  });
+};
+
+api.getPlans = (nextFn) => {
+  apiRequest({
+    method: 'GET',
+    path: '/plans'
+  }, data => {
+    nextFn(data.plans || []);
+  });
+};
+
+api.getSizes = api.getPlans;
+
+api.getSnapshots = (nextFn) => {
+  apiRequest({
+    method: 'GET',
+    path: '/snapshots'
+  }, data => {
+    nextFn(data.snapshots || []);
+  });
+};
+
+api.getKeys = (nextFn) => {
+  apiRequest({
+    method: 'GET',
+    path: '/ssh-keys'
+  }, data => {
+    nextFn(data.ssh_keys || []);
+  });
+};
+
+api.createKey = (keyData, nextFn) => {
+  apiRequest({
+    method: 'POST',
+    path: '/ssh-keys',
+    data: {
+      name: utils.createHashedKeyName(keyData),
+      ssh_key: keyData.trim()
+    }
+  }, data => {
+    nextFn(data.ssh_key);
+  });
+};
+
+// Internal functions
+
+function apiRequest(options, nextFn) {
+  const vars = utils.getVariables();
+  const apiKey = vars.VULTR_API_KEY;
+
+  if (!apiKey) {
+    log.failure('The variable VULTR_API_KEY is not set.');
+    log.failure('Go to https://my.vultr.com/settings/#settingsapi');
+    log.failure('to get your API key, then run the following command:');
+    return utils.die('overcast var set VULTR_API_KEY [your_api_key]');
+  }
+
+  const reqOptions = {
+    hostname: 'api.vultr.com',
+    port: 443,
+    path: '/v2' + options.path,
+    method: options.method || 'GET',
+    headers: {
+      'Authorization': `Bearer ${apiKey}`,
+      'Content-Type': 'application/json'
+    }
+  };
+
+  let reqData = '';
+  if (options.data) {
+    reqData = JSON.stringify(options.data);
+    reqOptions.headers['Content-Length'] = Buffer.byteLength(reqData);
+  }
+
+  const req = https.request(reqOptions, (res) => {
+    let data = '';
+    res.on('data', (chunk) => {
+      data += chunk;
+    });
+
+    res.on('end', () => {
+      try {
+        if (res.statusCode >= 200 && res.statusCode < 300) {
+          if (data && data.trim()) {
+            data = JSON.parse(data);
+          } else {
+            data = {};
+          }
+          nextFn(data);
+        } else {
+          let errorMessage = `Vultr API error: ${res.statusCode}`;
+          try {
+            if (data && data.trim()) {
+              const errorData = JSON.parse(data);
+              if (errorData.error) {
+                errorMessage += ` - ${errorData.error}`;
+              }
+            }
+          } catch (e) {
+            // Parse error, just use the status code
+          }
+          utils.die(errorMessage);
+        }
+      } catch (e) {
+        utils.die(`Error parsing Vultr API response: ${e.message}`);
+      }
+    });
+  });
+
+  req.on('error', (e) => {
+    utils.die(`Error making request to Vultr API: ${e.message}`);
+  });
+
+  if (reqData) {
+    req.write(reqData);
+  }
+
+  req.end();
+}
+
+function _create(args, data, nextFn) {
+  apiRequest({
+    method: 'POST',
+    path: '/instances',
+    data
+  }, response => {
+    if (response && response.instance) {
+      log.success('Instance created!');
+      log.faded('Waiting for it to boot up and get an IP address...');
+
+      waitForInstanceToBecomeActive(response.instance.id, () => {
+        api.getInstance(response.instance.id, instance => {
+          const result = {
+            name: args.name,
+            ip: instance.main_ip,
+            ssh_key: args['ssh-key'] || 'overcast.key',
+            ssh_port: args['ssh-port'] || '22',
+            user: 'root',
+            vultr: instance
+          };
+
+          log.success(`Instance ready! IP: ${instance.main_ip}`);
+
+          // Save the instance to the cluster
+          utils.saveInstanceToCluster(args.cluster || 'default', result, () => {
+            nextFn(result);
+          });
+        });
+      });
+    } else {
+      utils.die('Failed to create Vultr instance.');
+    }
+  });
+}
+
+function waitForInstanceToBecomeActive(instanceId, nextFn) {
+  api.getInstance(instanceId, instance => {
+    // Main IP is set and status is active
+    if (instance.status === 'active' && instance.main_ip && instance.main_ip !== '0.0.0.0') {
+      if (instance.power_status === 'running') {
+        nextFn(instance);
+      } else {
+        // Power it on if it's not running
+        apiRequest({
+          method: 'POST',
+          path: `/instances/${instanceId}/start`
+        }, () => {
+          // Wait a bit before checking again
+          setTimeout(() => {
+            waitForInstanceToBecomeActive(instanceId, nextFn);
+          }, 5000);
+        });
+      }
+    } else {
+      // Check again after a delay
+      setTimeout(() => {
+        waitForInstanceToBecomeActive(instanceId, nextFn);
+      }, 5000);
+    }
+  });
+}
+
+function waitForInstanceToBePoweredOff(instanceId, nextFn) {
+  api.getInstance(instanceId, instance => {
+    if (instance.power_status === 'stopped') {
+      nextFn(instance);
+    } else {
+      // Check again after a delay
+      setTimeout(() => {
+        waitForInstanceToBePoweredOff(instanceId, nextFn);
+      }, 5000);
+    }
+  });
+}
+
+function normalizeAndFindPropertiesForCreate(args, nextFn) {
+  args.image = args.image || args['image-id'] || args['os-id'] || DEFAULT_IMAGE;
+  args.plan = args.plan || args['plan-id'] || DEFAULT_PLAN;
+  args.region = args.region || args['region-id'] || DEFAULT_REGION;
+
+  // Get OS list first to determine if the image is an OS or an image
+  apiRequest({
+    method: 'GET',
+    path: '/os'
+  }, osData => {
+    const osList = osData.os || [];
+    const foundOS = osList.find(os =>
+      os.id.toString() === args.image.toString() ||
+      os.name.toLowerCase() === args.image.toLowerCase() ||
+      args.image.toLowerCase().includes(os.name.toLowerCase())
+    );
+
+    if (foundOS) {
+      // It's an OS
+      args['os-id'] = foundOS.id;
+      continueWithPlanAndRegion();
+    } else {
+      // Check if it's an app/snapshot image
+      apiRequest({
+        method: 'GET',
+        path: '/images'
+      }, imagesData => {
+        const images = imagesData.images || [];
+        const foundImage = images.find(img =>
+          img.id.toString() === args.image.toString() ||
+          img.name.toLowerCase() === args.image.toLowerCase() ||
+          imageIdOrOsId.toLowerCase().includes(img.name.toLowerCase())
+        );
+
+        if (foundImage) {
+          args['image-id'] = foundImage.id;
+          continueWithPlanAndRegion();
+        } else {
+          return utils.die(`No OS or image found that matches "${args.image}".`);
+        }
+      });
+    }
+  });
+
+  function continueWithPlanAndRegion() {
+    // Find plan
+    apiRequest({
+      method: 'GET',
+      path: '/plans'
+    }, data => {
+      const plans = data.plans || [];
+      const foundPlan = plans.find(plan =>
+        plan.id.toString() === args.plan.toString() ||
+        plan.id.toLowerCase() === args.plan.toLowerCase() ||
+        args.plan.toLowerCase().includes(plan.id.toLowerCase())
+      );
+
+      if (!foundPlan) {
+        return utils.die(`No plan found that matches "${args.plan}".`);
+      }
+
+      args['plan-id'] = foundPlan.id;
+
+      // Find region
+      apiRequest({
+        method: 'GET',
+        path: '/regions'
+      }, data => {
+        const regions = data.regions || [];
+        const foundRegion = regions.find(region =>
+          region.id.toString() === args.region.toString() ||
+          region.id.toLowerCase() === args.region.toLowerCase() ||
+          args.region.toLowerCase().includes(region.id.toLowerCase())
+        );
+
+        if (!foundRegion) {
+          return utils.die(`No region found that matches "${args.region}".`);
+        }
+
+        args['region-id'] = foundRegion.id;
+
+        // Clean up temporary args
+        ['image', 'plan', 'region'].forEach(key => {
+          delete args[key];
+        });
+
+        nextFn();
+      });
+    });
+  }
+}
+
+function getOrCreateOvercastKeyID(pubKeyPath, nextFn) {
+  const keyData = fs.readFileSync(pubKeyPath, 'utf8');
+  const keyName = utils.createHashedKeyName(keyData);
+
+  api.getKeys(keys => {
+    const existingKey = keys.find(key => key.name === keyName);
+
+    if (existingKey) {
+      log.faded(`Using existing SSH key: ${pubKeyPath}`);
+      nextFn(existingKey.id);
+    } else {
+      log.faded(`Uploading new SSH key: ${pubKeyPath}`);
+      api.createKey(keyData, newKey => {
+        nextFn(newKey.id);
+      });
+    }
+  });
+}

--- a/src/providers/vultr.js
+++ b/src/providers/vultr.js
@@ -356,7 +356,7 @@ function apiRequest(options, nextFn) {
     log.failure('The variable VULTR_API_KEY is not set.');
     log.failure('Go to https://my.vultr.com/settings/#settingsapi');
     log.failure('to get your API key, then run the following command:');
-    return utils.die('overcast var set VULTR_API_KEY [your_api_key]');
+    return utils.die('overcast vars set VULTR_API_KEY [your_api_key]');
   }
 
   const reqOptions = {

--- a/test/integration/vultr.spec.js
+++ b/test/integration/vultr.spec.js
@@ -1,0 +1,177 @@
+import { overcast, tearDown, expectInLog, expectNotInLog } from './utils.js';
+
+describe('vultr', () => {
+
+  const instanceName = 'VULTR_TEST_NAME';
+
+  beforeAll((nextFn) => {
+    tearDown(nextFn);
+  });
+
+  describe('create', () => {
+    it('should create an instance', (nextFn) => {
+      overcast(`vultr create ${instanceName}`, (logs) => {
+        expectInLog(expect, logs, `Instance "${instanceName}" (192.168.100.103) saved`);
+        expectInLog(expect, logs, 'Connection established');
+        overcast('list', (logs) => {
+          expectInLog(expect, logs, '(root@192.168.100.103:22)');
+          nextFn();
+        });
+      });
+    });
+
+    it('should not allow duplicate instance names', (nextFn) => {
+      overcast(`vultr create ${instanceName}`, (logs) => {
+        expectInLog(expect, logs, `Instance "${instanceName}" already exists`);
+        nextFn();
+      });
+    });
+  });
+
+  describe('boot', () => {
+    it('should not allow an invalid instance to be booted', (nextFn) => {
+      overcast('vultr boot INVALID_NAME', (logs) => {
+        expectInLog(expect, logs, 'No instance found matching "INVALID_NAME"');
+        nextFn();
+      });
+    });
+
+    it('should boot a valid instance', (nextFn) => {
+      overcast(`vultr boot ${instanceName}`, (logs) => {
+        expectInLog(expect, logs, `Instance "${instanceName}" booted`);
+        nextFn();
+      });
+    });
+  });
+
+  describe('reboot', () => {
+    it('should not allow an invalid instance to be rebooted', (nextFn) => {
+      overcast('vultr reboot INVALID_NAME', (logs) => {
+        expectInLog(expect, logs, 'No instance found matching "INVALID_NAME"');
+        nextFn();
+      });
+    });
+
+    it('should reboot an instance', (nextFn) => {
+      overcast(`vultr reboot ${instanceName}`, (logs) => {
+        expectInLog(expect, logs, `Instance "${instanceName}" rebooted`);
+        nextFn();
+      });
+    });
+  });
+
+  describe('shutdown', () => {
+    it('should not allow an invalid instance to be shut down', (nextFn) => {
+      overcast('vultr shutdown INVALID_NAME', (logs) => {
+        expectInLog(expect, logs, 'No instance found matching "INVALID_NAME"');
+        nextFn();
+      });
+    });
+
+    it('should shutdown an instance', (nextFn) => {
+      overcast(`vultr shutdown ${instanceName}`, (logs) => {
+        expectInLog(expect, logs, `Instance "${instanceName}" has been shut down`);
+        nextFn();
+      });
+    });
+  });
+
+  describe('destroy', () => {
+    it('should not allow an invalid instance to be destroyed', (nextFn) => {
+      overcast('vultr destroy INVALID_NAME', (logs) => {
+        expectInLog(expect, logs, 'No instance found matching "INVALID_NAME"');
+        nextFn();
+      });
+    });
+
+    it('should destroy an instance', (nextFn) => {
+      overcast(`vultr destroy ${instanceName}`, (logs) => {
+        expectInLog(expect, logs, `Instance "${instanceName}" destroyed`);
+        overcast('list', (logs) => {
+          expectNotInLog(expect, logs, '(root@192.168.100.103:22)');
+          nextFn();
+        });
+      });
+    });
+  });
+
+  // Additional Vultr-specific commands
+
+  describe('rebuild', () => {
+    it('should not allow an invalid instance to be rebuilt', (nextFn) => {
+      overcast('vultr rebuild INVALID_NAME ubuntu_22_04_x64', (logs) => {
+        expectInLog(expect, logs, 'No instance found matching "INVALID_NAME"');
+        nextFn();
+      });
+    });
+  });
+
+  describe('resize', () => {
+    it('should not allow an invalid instance to be resized', (nextFn) => {
+      overcast('vultr resize INVALID_NAME vc2-2c-4gb', (logs) => {
+        expectInLog(expect, logs, 'No instance found matching "INVALID_NAME"');
+        nextFn();
+      });
+    });
+  });
+
+  describe('snapshot', () => {
+    it('should not allow an invalid instance to be snapshotted', (nextFn) => {
+      overcast('vultr snapshot INVALID_NAME test-snapshot', (logs) => {
+        expectInLog(expect, logs, 'No instance found matching "INVALID_NAME"');
+        nextFn();
+      });
+    });
+  });
+
+  describe('sync', () => {
+    it('should not allow an invalid instance to be synced', (nextFn) => {
+      overcast('vultr sync INVALID_NAME', (logs) => {
+        expectInLog(expect, logs, 'No instance found matching "INVALID_NAME"');
+        nextFn();
+      });
+    });
+  });
+
+  // Listing commands
+
+  describe('instances', () => {
+    it('should list instances', (nextFn) => {
+      overcast('vultr instances', (logs) => {
+        nextFn();
+      });
+    });
+  });
+
+  describe('images', () => {
+    it('should list images', (nextFn) => {
+      overcast('vultr images', (logs) => {
+        nextFn();
+      });
+    });
+  });
+
+  describe('regions', () => {
+    it('should list regions', (nextFn) => {
+      overcast('vultr regions', (logs) => {
+        nextFn();
+      });
+    });
+  });
+
+  describe('plans', () => {
+    it('should list plans', (nextFn) => {
+      overcast('vultr plans', (logs) => {
+        nextFn();
+      });
+    });
+  });
+
+  describe('snapshots', () => {
+    it('should list snapshots', (nextFn) => {
+      overcast('vultr snapshots', (logs) => {
+        nextFn();
+      });
+    });
+  });
+});


### PR DESCRIPTION
Resolves #58. Unit and manual testing remain to be done. Intentionally not adding any new npm dependencies, so the provider code uses `https.request` to hit the Vultr API v2 endpoints directly.

This code was largely written by Claude 3.7 Sonnet.

Tasks:

- [x] Unit tests
- [x] Sign up for Vultr account
- [ ] Manual testing (help would be appreciated here!)